### PR TITLE
Add button in address bar

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -43,7 +43,7 @@
       },
       "description": "Show the 'Quick Bookmark To Folder' popup in page action"
     }
-  }
+  },
   "background": {
     "scripts": ["scripts/background.js"]
   }

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -17,6 +17,15 @@
     "default_title": "Quick Bookmark To Folder",
     "default_popup": "html/popup.html"
   },
+  "page_action": {
+    "browser_style": true,
+    "default_icon": {
+      "19": "images/icon-19.png",
+      "38": "images/icon-38.png"
+    },
+    "default_title": "Quick Bookmark To Folder",
+    "default_popup": "html/popup.html"
+  },
   "permissions": [
     "bookmarks",
     "tabs"
@@ -26,7 +35,11 @@
       "suggested_key": {
         "default": "Ctrl+Shift+K"
       },
-      "description": "Show the 'Quick Bookmark To Folder' popup"
+      "description": "Show the 'Quick Bookmark To Folder' popup in browser"
     }
+  },
+  "background": {
+    "scripts": ["scripts/background.js"]
   }
 }
+

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -35,9 +35,15 @@
       "suggested_key": {
         "default": "Ctrl+Shift+K"
       },
-      "description": "Show the 'Quick Bookmark To Folder' popup in browser"
+      "description": "Show the 'Quick Bookmark To Folder' popup in browser action"
+    },
+    "_execute_page_action": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+L" // example
+      },
+      "description": "Show the 'Quick Bookmark To Folder' popup in page action"
     }
-  },
+  }
   "background": {
     "scripts": ["scripts/background.js"]
   }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -25,7 +25,7 @@ browser.bookmarks.onRemoved.addListener(function hidePageAction() {
 
 // handle messages
 function handleMessage(request) {
-  if (request.greeting = "Adding Bookmark To Folder") {
+  if (request.greeting == "Adding Bookmark To Folder") {
     var removingBookmark = browser.bookmarks.remove(bookmarkId);
   }
 }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1,12 +1,15 @@
+var bookmarkId;
+
 function startup() {
-	console.log("Initializing add-on...");
+    console.log("Initializing add-on...");
 }
 
 // show page action when bookmark is created on current tab
-browser.bookmarks.onCreated.addListener(function showPageAction() {
+browser.bookmarks.onCreated.addListener(function showPageAction(id) {
+  bookmarkId = id; // save bookmark id
   var gettingActiveTab = browser.tabs.query({active: true, currentWindow: true});
   gettingActiveTab.then((tabs) => {
-	console.log("showing page action");
+    console.log("showing page action");
     browser.pageAction.show(tabs[0].id);
   });
 });
@@ -15,9 +18,19 @@ browser.bookmarks.onCreated.addListener(function showPageAction() {
 browser.bookmarks.onRemoved.addListener(function hidePageAction() {
   var gettingActiveTab = browser.tabs.query({active: true, currentWindow: true});
   gettingActiveTab.then((tabs) => {
-	console.log("hiding page action");
+    console.log("hiding page action");
     browser.pageAction.hide(tabs[0].id);
   });
 });
 
+// handle messages
+function handleMessage(request) {
+  if (request.greeting = "Adding Bookmark To Folder") {
+    var removingBookmark = browser.bookmarks.remove(bookmarkId);
+  }
+}
+
+browser.runtime.onMessage.addListener(handleMessage);
+
 startup();
+

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1,0 +1,23 @@
+function startup() {
+	console.log("Initializing add-on...");
+}
+
+// show page action when bookmark is created on current tab
+browser.bookmarks.onCreated.addListener(function showPageAction() {
+  var gettingActiveTab = browser.tabs.query({active: true, currentWindow: true});
+  gettingActiveTab.then((tabs) => {
+	console.log("showing page action");
+    browser.pageAction.show(tabs[0].id);
+  });
+});
+
+// hide page action when bookmark is removed on current tab
+browser.bookmarks.onRemoved.addListener(function hidePageAction() {
+  var gettingActiveTab = browser.tabs.query({active: true, currentWindow: true});
+  gettingActiveTab.then((tabs) => {
+	console.log("hiding page action");
+    browser.pageAction.hide(tabs[0].id);
+  });
+});
+
+startup();

--- a/app/scripts/popup.js
+++ b/app/scripts/popup.js
@@ -90,6 +90,9 @@ var hideNoMatches = function ()
 
 var addBookmarkToFolder = function (folderId)
 {
+    // Message background script to delete duplicate bookmark
+    notifyBackgroundPage("Adding Bookmark To Folder");
+    
     // Get the current tab information (url and title)
     var tabQuery = { active: true, currentWindow: true };
 
@@ -304,3 +307,10 @@ overlayButtonElement.addEventListener("click", function()
 setTimeout(() => {
     folderInputElement.focus();
 }, 300);
+
+// send messages to background script
+function notifyBackgroundPage(greeting) {
+  var sending = browser.runtime.sendMessage({
+    greeting: greeting
+  });
+}


### PR DESCRIPTION
This is a cleaner way to use Quick Bookmark to Folder. The icon will only appear if the user wants to make a bookmark.

It creates a button in the address bar, called the "page action," that will appear when the bookmark star icon is clicked. Removing the bookmark will hide the page action with it. 

Note: Clicking the bookmark star icon and then using either the page action or browser action will create a duplicate bookmark. Please add a feature to delete the old bookmark.

Edit: I added a way to prevent duplicate bookmarks.